### PR TITLE
Update for pymodbus 3.11

### DIFF
--- a/custom_components/solaredge_modbus/__init__.py
+++ b/custom_components/solaredge_modbus/__init__.py
@@ -7,8 +7,8 @@ import operator
 from typing import cast
 
 from pymodbus.client import AsyncModbusTcpClient
-from pymodbus.constants import Endian
 from pymodbus.exceptions import ModbusException
+from .payload import Endian, BinaryPayloadDecoder
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
@@ -52,7 +52,6 @@ from .const import (
     STORAGE_CHARGE_DISCHARGE_MODE,
     STORAGE_CONTROL_MODE,
 )
-from .payload import BinaryPayloadDecoder
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/solaredge_modbus/__init__.py
+++ b/custom_components/solaredge_modbus/__init__.py
@@ -302,7 +302,7 @@ class SolaredgeModbusHub:
         """Read holding registers."""
         async with self._lock:
             return await self._client.read_holding_registers(
-                address=address, count=count, slave=unit
+                address=address, count=count, device_id=unit
             )
 
     async def write_registers(self, unit, address, payload):
@@ -310,7 +310,7 @@ class SolaredgeModbusHub:
         try:
             async with self._lock:
                 return await self._client.write_registers(
-                    address=address, values=payload, slave=unit
+                    address=address, values=payload, device_id=unit
                 )
         except ModbusException as err:
             raise HomeAssistantError(err) from err
@@ -320,7 +320,7 @@ class SolaredgeModbusHub:
         try:
             async with self._lock:
                 return await self._client.write_register(
-                    address=address, value=payload, slave=unit
+                    address=address, value=payload, device_id=unit
                 )
         except ModbusException as err:
             raise HomeAssistantError(err) from err

--- a/custom_components/solaredge_modbus/manifest.json
+++ b/custom_components/solaredge_modbus/manifest.json
@@ -2,7 +2,7 @@
   "domain": "solaredge_modbus",
   "name": "SolarEdge Modbus",
   "documentation": "https://github.com/binsentsu/home-assistant-solaredge-modbus",
-  "requirements": ["pymodbus==3.9.2"],
+  "requirements": ["pymodbus==3.11.1"],
   "dependencies": [],
   "codeowners": ["@binsentsu"],
   "config_flow": true,

--- a/custom_components/solaredge_modbus/number.py
+++ b/custom_components/solaredge_modbus/number.py
@@ -2,8 +2,7 @@
 
 import logging
 
-from pymodbus.constants import Endian
-from pymodbus.payload import BinaryPayloadBuilder
+from .payload import Endian, BinaryPayloadBuilder
 
 from homeassistant.components.number import NumberEntity
 from homeassistant.const import CONF_NAME

--- a/custom_components/solaredge_modbus/payload.py
+++ b/custom_components/solaredge_modbus/payload.py
@@ -9,15 +9,24 @@ from __future__ import annotations
 __all__ = [
     "BinaryPayloadBuilder",
     "BinaryPayloadDecoder",
+    "Endian",
 ]
 
 # pylint: disable=missing-type-doc
 from struct import pack, unpack
 
-from pymodbus.constants import Endian
+from enum import Enum
+
 from pymodbus.exceptions import ParameterException
 from pymodbus.logging import Log
 from pymodbus.pdu.pdu import pack_bitstring, unpack_bitstring
+
+
+class Endian(str, Enum):
+    """Enumeration of byte endianness."""
+
+    BIG = ">"
+    LITTLE = "<"
 
 WC = {"b": 1, "h": 2, "e": 2, "i": 4, "l": 4, "q": 8, "f": 4, "d": 8}
 
@@ -29,7 +38,7 @@ class BinaryPayloadBuilder:
     however it saves time looking up the format strings.
     What follows is a simple example::
 
-        builder = BinaryPayloadBuilder(byteorder=Endian.Little)
+        builder = BinaryPayloadBuilder(byteorder=Endian.LITTLE)
         builder.add_8bit_uint(1)
         builder.add_16bit_uint(2)
         payload = builder.build()


### PR DESCRIPTION
## Summary
- use local payload module for Endian and builder/decoder
- bump pymodbus requirement to 3.11.1

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b304fd0728833093e392f25f5dd6f3